### PR TITLE
removes getTopicPromises() from workorder & calls from mediator instead

### DIFF
--- a/lib/client/workorder-client/index.js
+++ b/lib/client/workorder-client/index.js
@@ -6,6 +6,13 @@ var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
 var mediator, manager, workorderSyncSubscribers;
 
 
+var topicDefaults = {
+  "DONE_PREFIX": CONSTANTS.DONE_PREFIX,
+  "ERROR_PREFIX": CONSTANTS.ERROR_PREFIX,
+  "TOPIC_TIMEOUT": CONSTANTS.TOPIC_TIMEOUT
+};
+
+
 /**
  *
  * Creating a new workorder.
@@ -15,17 +22,24 @@ var mediator, manager, workorderSyncSubscribers;
 function create(workorderToCreate) {
 
   //Creating a unique channel to get the response
-  var topicUid = shortid.generate();
+  var topicUid = "testtopicuid1";// shortid.generate();
 
   var topicParams = {topicUid: topicUid, itemToCreate: workorderToCreate};
 
+  /*
   var donePromise = mediator.promise(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.DONE_PREFIX, topicUid));
-
   var errorPromise = mediator.promise(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.ERROR_PREFIX, topicUid));
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), topicParams);
 
   return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
+  */
+
+  var topicName = workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE);
+
+  mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), topicParams);
+
+  return workorderSyncSubscribers.getErrorAndDoneTopicPromises( { }, topicDefaults, topicName, topicUid);
 }
 
 /**
@@ -39,7 +53,6 @@ function update(workorderToUpdate) {
   var topicParams = {topicUid: workorderToUpdate.id, itemToUpdate: workorderToUpdate};
 
   var donePromise = mediator.promise(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.DONE_PREFIX, topicParams.topicUid));
-
   var errorPromise = mediator.promise(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.ERROR_PREFIX, topicParams.topicUid));
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE), topicParams);

--- a/lib/client/workorder-client/index.js
+++ b/lib/client/workorder-client/index.js
@@ -5,28 +5,6 @@ var CONSTANTS = require('../../constants');
 var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
 var mediator, manager, workorderSyncSubscribers;
 
-/**
- *
- * Getting Promises for done and error topics.
- *
- * @param doneTopicPromise  - A promise for the done topic.
- * @param errorTopicPromise - A promise for the error topic.
- * @returns {*}
- */
-function getTopicPromises(doneTopicPromise, errorTopicPromise) {
-  var deferred = q.defer();
-
-  doneTopicPromise.then(function(createdWorkorder) {
-    deferred.resolve(createdWorkorder);
-  });
-
-  errorTopicPromise.then(function(error) {
-    deferred.reject(error);
-  });
-
-  return deferred.promise;
-}
-
 
 /**
  *
@@ -47,7 +25,7 @@ function create(workorderToCreate) {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), topicParams);
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**
@@ -66,7 +44,7 @@ function update(workorderToUpdate) {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE), topicParams);
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /***
@@ -82,7 +60,7 @@ function read(workorderId) {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ), {id: workorderId, topicUid: workorderId});
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**
@@ -95,7 +73,7 @@ function list() {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST));
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**
@@ -113,7 +91,7 @@ function remove(workorderToRemove) {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE),  {id: workorderToRemove.id, topicUid: workorderToRemove.id});
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**
@@ -127,7 +105,7 @@ function start() {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.START));
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**
@@ -140,7 +118,7 @@ function stop() {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.STOP));
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**
@@ -153,7 +131,7 @@ function forceSync() {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.FORCE_SYNC));
 
-  return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,6 +4,7 @@ module.exports = {
   SYNC_TOPIC_PREFIX: "wfm:sync",
   ERROR_PREFIX: "error",
   DONE_PREFIX: "done",
+  TOPIC_TIMEOUT: 1000,
   TOPICS: {
     CREATE: "create",
     UPDATE: "update",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workorder",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "An workorder module for WFM",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "4.15.2",
-    "fh-wfm-mediator": "0.3.1",
+    "fh-wfm-mediator": "0.4.0-alpha.629.4",
     "lodash": "4.7.0",
     "q": "1.4.1",
     "shortid": "2.2.6"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.host.url=https://sonarqube.com
 sonar.projectKey=raincatcher-workorder
 sonar.projectName=raincatcher-workorder
-sonar.projectVersion=0.2.1
+sonar.projectVersion=0.3.0
 
 sonar.sources=./lib
 sonar.language=js


### PR DESCRIPTION
moves getTopicPromises() out of module & calls them from mediator instead

part of https://issues.jboss.org/browse/RAINCATCH-629 which involved refactoring raincatcher-workorder and raincatcher-workflow to remove the getTopicPromises() and getErrorAndDoneTopicPromises() functionality in them, and move them into the mediator instead.

wip - getTopicPromises() & getErrorAndDoneTopicPromises() calls only begun to be removed. Example of finished refactoring in workflow pr for 629 - https://github.com/feedhenry-raincatcher/raincatcher-workflow/pull/19


related prs: 
https://github.com/feedhenry-raincatcher/raincatcher-workflow/pull/19
https://github.com/feedhenry-raincatcher/raincatcher-mediator/pull/23