### PR TITLE
Added filtering unique identifiers to separate lists with different filters

### DIFF
--- a/lib/cloud/index.js
+++ b/lib/cloud/index.js
@@ -29,8 +29,16 @@ module.exports = function(mediator) {
   });
 
   workorderCloudTopics.on('list', function(listOptions) {
+    var self = this;
     listOptions = listOptions || {};
-    return workorderCloudDataTopics.request('list', listOptions.filter, {uid: null});
+    listOptions.filter = listOptions.filter || {};
+    listOptions.filter.topicUid = listOptions.topicUid || shortid.generate();
+
+    workorderCloudDataTopics.request('list', listOptions.filter, {uid: listOptions.filter.topicUid}).then(function(list) {
+      self.mediator.publish(workorderCloudTopics.getTopic('list', 'done', listOptions.filter.topicUid), list);
+    }).catch(function(err) {
+      self.mediator.publish(workorderCloudTopics.getTopic('list', 'error', listOptions.filter.topicUid), err);
+    });
   });
 
   workorderCloudTopics.on('update', function(workorderToUpdate) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workorder",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "An workorder module for WFM",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Motivation

List topics can contain different filters based on parameters passed from sync. In order to ensure that the `done` topics are related to the correct filter, we need to include a topic unique identifier.